### PR TITLE
Add base converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # test-codex
+
 a simple test repository
+
+## Base Converter
+
+This repository now includes a simple command line base converter written in
+Python. Use it to convert numbers between bases 2 and 36.
+
+### Usage
+
+```bash
+python src/convert_base.py NUMBER FROM_BASE TO_BASE
+```
+
+For example, to convert hexadecimal `FF` to decimal:
+
+```bash
+python src/convert_base.py FF 16 10
+```
+

--- a/src/convert_base.py
+++ b/src/convert_base.py
@@ -1,0 +1,42 @@
+import argparse
+from string import digits as DIGITS
+
+ALPHABET = DIGITS + "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def int_to_base(n: int, base: int) -> str:
+    """Convert an integer to a string in the given base."""
+    if base < 2 or base > 36:
+        raise ValueError("Base must be between 2 and 36")
+    if n == 0:
+        return '0'
+    sign = '-' if n < 0 else ''
+    n = abs(n)
+    result = []
+    while n:
+        n, rem = divmod(n, base)
+        result.append(ALPHABET[rem])
+    return sign + ''.join(reversed(result))
+
+
+def convert_base(number_str: str, from_base: int, to_base: int) -> str:
+    """Convert number_str from from_base to to_base."""
+    if from_base < 2 or from_base > 36 or to_base < 2 or to_base > 36:
+        raise ValueError("Bases must be between 2 and 36")
+    # int() handles sign as well
+    n = int(number_str, from_base)
+    return int_to_base(n, to_base)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Base converter")
+    parser.add_argument("number", help="Number to convert")
+    parser.add_argument("from_base", type=int, help="Base of the input number")
+    parser.add_argument("to_base", type=int, help="Base to convert to")
+    args = parser.parse_args()
+
+    print(convert_base(args.number, args.from_base, args.to_base))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_convert_base.py
+++ b/tests/test_convert_base.py
@@ -1,0 +1,22 @@
+import unittest
+from src import convert_base
+
+class TestBaseConverter(unittest.TestCase):
+    def test_binary_to_decimal(self):
+        self.assertEqual(convert_base.convert_base('1010', 2, 10), '10')
+
+    def test_decimal_to_hex(self):
+        self.assertEqual(convert_base.convert_base('255', 10, 16), 'FF')
+
+    def test_hex_to_binary(self):
+        self.assertEqual(convert_base.convert_base('1F', 16, 2), '11111')
+
+    def test_negative_numbers(self):
+        self.assertEqual(convert_base.convert_base('-10', 10, 2), '-1010')
+
+    def test_base_out_of_range(self):
+        with self.assertRaises(ValueError):
+            convert_base.convert_base('1', 1, 10)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `convert_base.py` with CLI
- document usage in README
- add unit tests for base converter
- ignore Python bytecode

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684058c08ce4832dbd0d362c15a2ae18